### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@
 ### Erlang
  * [Erlang Solutions](https://www.youtube.com/user/ErlangSolutions)
 
-##Official Channels of Software Companies or Software Tools
+## Official Channels of Software Companies or Software Tools
 
 * [NodeJS](https://www.youtube.com/channel/UCQPYJluYC_sn_Qz_XE-YbTQ) - Official channel of Node.js
 * [Spring Framework](https://www.youtube.com/channel/UC7yfnfvEUlXUIfm8rGLwZdA) - Offical channel of Spring


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
